### PR TITLE
Fix query_tx_events

### DIFF
--- a/crates/relayer/src/chain/namada/query.rs
+++ b/crates/relayer/src/chain/namada/query.rs
@@ -7,6 +7,7 @@ use namada::ledger::queries::RPC;
 use namada::tendermint::block::Height as TmHeight;
 use namada::tendermint_rpc::Client;
 use namada::types::storage::{BlockHeight, Epoch, Key, PrefixValue};
+use namada_apps::node::ledger::shell::ErrorCodes;
 use tendermint::abci::{Event, EventAttribute};
 use tendermint::merkle::proof::{ProofOp, ProofOps};
 
@@ -129,7 +130,7 @@ impl NamadaChain {
                     .map_err(|_| Error::invalid_height_no_source())?;
                 // Check if the tx is valid
                 let code = applied.get("code").expect("The code should exist");
-                if code != "0" {
+                if *code != String::from(ErrorCodes::Ok) {
                     return Ok(vec![IbcEventWithHeight::new(
                         IbcEvent::ChainError(format!(
                             "The transaction was invalid: Event {:?}",


### PR DESCRIPTION
Hermes misunderstood a Namada IBC transaction failed though it actually succeeded.
The issue could happen when another transaction fails in the same block where the IBC transaction is applied.

The cause is that `query_tx_events` caught unrelated failure transaction events.
By this fix, `query_tx_events` checks the "code" of the transaction to know whether or not it has been applied.
Only when the transaction has been applied successfully, IBC events are collected.