### PR TITLE
Fix CompatMode

### DIFF
--- a/crates/relayer/src/chain/namada.rs
+++ b/crates/relayer/src/chain/namada.rs
@@ -108,7 +108,7 @@ impl NamadaChain {
             Mode::Push { url, batch_delay } => EventSource::websocket(
                 self.config.id.clone(),
                 url.clone(),
-                CompatMode::V0_34,
+                CompatMode::V0_37,
                 *batch_delay,
                 self.rt.clone(),
             ),


### PR DESCRIPTION
Hermes subscribes Tendermint `NewBlock` event and cleans pending packets up every `clear_interval` blocks.
For this bug, when a new block has items incompatible with v0.34, the `NewBlock` event cannot be decoded.
That's why Hermes doesn't clean up pending packets.