### PR TITLE
Fix Tendermint client for Namada

### DIFF
--- a/crates/relayer/src/error.rs
+++ b/crates/relayer/src/error.rs
@@ -11,6 +11,7 @@ use namada::tendermint::Error as AbciPlusTmError;
 use namada::tendermint::Error as NamadaTendermintError;
 use namada::tendermint_proto::Error as AbciPlusTmProtoError;
 use namada::tendermint_rpc::Error as TendermintAbciPlusRpcError;
+use namada::tendermint_rpc::Error as NamadaTmRpcError;
 use namada::types::token::Amount;
 use prost::{DecodeError, EncodeError};
 use regex::Regex;
@@ -613,6 +614,11 @@ define_error! {
         NamadaTendermint
             [ NamadaTendermintError ]
             |_| { "Tendermint error" },
+
+        NamadaTendermintRpc
+            { url: namada::tendermint_rpc::Url }
+            [ NamadaTmRpcError ]
+            |e| { format!("RPC error to endpoint {}", e.url) },
 
         NamadaQuery
             { description: String }


### PR DESCRIPTION
When `rpc_addr` is `https://{host}:{port}/{path}`, Namada client didn't work because the specified address was wrong.
This fix sets the ledger address as `rpc_addr` itself in the config.
(We need to convert `Url` for Namada `tendermint-rpc`.)