### PR TITLE
Updated the Namada SDK dependency and adjusted denominations.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "arc-swap",
  "backtrace",
  "canonical-path",
- "clap",
+ "clap 3.2.25",
  "color-eyre",
  "fs-err",
  "once_cell",
@@ -968,7 +968,7 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
  "strsim",
@@ -977,12 +977,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+dependencies = [
+ "anstyle",
+ "clap_lex 0.7.1",
+]
+
+[[package]]
 name = "clap_complete"
 version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
 dependencies = [
- "clap",
+ "clap 3.2.25",
 ]
 
 [[package]]
@@ -1006,6 +1025,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "coins-bip32"
@@ -3267,7 +3292,7 @@ name = "ibc-relayer-cli"
 version = "1.8.2"
 dependencies = [
  "abscissa_core",
- "clap",
+ "clap 3.2.25",
  "clap_complete",
  "color-eyre",
  "console",
@@ -3974,7 +3999,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "namada_account"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "linkme",
@@ -3988,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "namada_controller"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -3998,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "namada_core"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "bech32 0.8.1",
  "borsh 1.5.0",
@@ -4028,6 +4053,7 @@ dependencies = [
  "prost-types",
  "rand 0.8.5",
  "rand_core 0.6.4",
+ "ripemd",
  "serde",
  "serde_json",
  "sha2 0.9.9",
@@ -4045,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "namada_ethereum_bridge"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "ethers",
@@ -4072,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "namada_events"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "linkme",
@@ -4088,7 +4114,7 @@ dependencies = [
 [[package]]
 name = "namada_gas"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "linkme",
@@ -4103,7 +4129,7 @@ dependencies = [
 [[package]]
 name = "namada_governance"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "itertools 0.12.1",
@@ -4126,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "namada_ibc"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "ibc",
@@ -4154,7 +4180,7 @@ dependencies = [
 [[package]]
 name = "namada_macros"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -4166,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "namada_merkle_tree"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "eyre",
@@ -4181,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "namada_migrations"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "lazy_static",
  "linkme",
@@ -4191,18 +4217,19 @@ dependencies = [
 [[package]]
 name = "namada_parameters"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "namada_core",
  "namada_macros",
  "namada_storage",
+ "smooth-operator",
  "thiserror",
 ]
 
 [[package]]
 name = "namada_proof_of_stake"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "konst",
@@ -4227,7 +4254,7 @@ dependencies = [
 [[package]]
 name = "namada_replay_protection"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "namada_core",
 ]
@@ -4235,13 +4262,14 @@ dependencies = [
 [[package]]
 name = "namada_sdk"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "async-trait",
  "bimap",
  "borsh 1.5.0",
  "borsh-ext",
  "circular-queue",
+ "clap 4.5.7",
  "data-encoding",
  "derivation-path",
  "duration-str",
@@ -4281,7 +4309,6 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "regex",
- "ripemd",
  "serde",
  "serde_json",
  "sha2 0.9.9",
@@ -4301,7 +4328,7 @@ dependencies = [
 [[package]]
 name = "namada_shielded_token"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "masp_primitives",
@@ -4318,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "namada_state"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "itertools 0.12.1",
@@ -4342,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "namada_storage"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "itertools 0.12.1",
@@ -4362,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "namada_token"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "namada_core",
@@ -4377,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "namada_trans_token"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "konst",
  "namada_core",
@@ -4388,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "namada_tx"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.5.0",
@@ -4416,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "namada_vote_ext"
 version = "0.39.0"
-source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
+source = "git+https://github.com/anoma/namada?branch=murisi/draft-with-masp-ibc-replay-protection#76fab4c6c7b1c12c65aa02cf4f2923429bd4da1d"
 dependencies = [
  "borsh 1.5.0",
  "linkme",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,10 @@ tendermint-rpc                   = { version = "0.36.0" }
 tendermint-testgen               = { version = "0.36.0" }
 
 # Namada dependencies
-namada_ibc        = { git = "https://github.com/anoma/namada", version = "0.39.0" }
-namada_parameters = { git = "https://github.com/anoma/namada", version = "0.39.0" }
-namada_sdk        = { git = "https://github.com/anoma/namada", version = "0.39.0" }
-namada_token      = { git = "https://github.com/anoma/namada", version = "0.39.0" }
+namada_ibc        = { git = "https://github.com/anoma/namada", branch = "murisi/draft-with-masp-ibc-replay-protection" }
+namada_parameters = { git = "https://github.com/anoma/namada", branch = "murisi/draft-with-masp-ibc-replay-protection" }
+namada_sdk        = { git = "https://github.com/anoma/namada", branch = "murisi/draft-with-masp-ibc-replay-protection" }
+namada_token      = { git = "https://github.com/anoma/namada", branch = "murisi/draft-with-masp-ibc-replay-protection" }
 
 # Other dependencies
 abscissa_core            = "=0.6.0"

--- a/crates/relayer/src/chain/namada/tx.rs
+++ b/crates/relayer/src/chain/namada/tx.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 
 use ibc_proto::google::protobuf::Any;
 use itertools::Itertools;
+use namada_ibc::{MsgAcknowledgement, MsgRecvPacket, MsgTimeout};
 use namada_sdk::address::{Address, ImplicitAddress};
 use namada_sdk::args::{self, TxBuilder};
 use namada_sdk::args::{InputAmount, Tx as TxArgs, TxCustom};
@@ -19,7 +20,6 @@ use namada_sdk::ibc::core::channel::types::msgs::{
     MsgTimeout as IbcMsgTimeout, ACKNOWLEDGEMENT_TYPE_URL, RECV_PACKET_TYPE_URL, TIMEOUT_TYPE_URL,
 };
 use namada_sdk::ibc::core::host::types::identifiers::{ChannelId, PortId};
-use namada_ibc::{MsgAcknowledgement, MsgRecvPacket, MsgTimeout};
 use namada_sdk::masp::{PaymentAddress, TransferTarget};
 use namada_sdk::masp_primitives::transaction::Transaction as MaspTransaction;
 use namada_sdk::{signing, tx, Namada};
@@ -258,7 +258,7 @@ impl NamadaChain {
 
         if let Some((receiver, token, amount)) = transfer {
             self.rt.block_on(self.shielded_sync())?;
-            let amount = InputAmount::Unvalidated(
+            let amount = InputAmount::Validated(
                 amount
                     .parse()
                     .map_err(|e| Error::send_tx(format!("invalid amount: {e}")))?,


### PR DESCRIPTION
Adjusting Hermes to work with https://github.com/anoma/namada/pull/3409 . The incompatibilities with the linked PR mainly arose from:
* the redenomination of amounts used in the IBC packets to facilitate computations with MASP amounts
* changes in the derivation of `TransparentAddress`es to include IBC receiver data as a way to attain replay protection