### PR TITLE
Updated Namada SDK to the one provided by the hardware integration branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3972,7 +3972,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=12ed8b060b295c06502a2ff8468e4a941cb7cca4#12ed8b060b295c06502a2ff8468e4a941cb7cca4"
+source = "git+https://github.com/anoma/masp?rev=2914e6ff9a922bae8f1cb63a79d796a69af3d8aa#2914e6ff9a922bae8f1cb63a79d796a69af3d8aa"
 dependencies = [
  "borsh",
  "chacha20",
@@ -3985,7 +3985,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=12ed8b060b295c06502a2ff8468e4a941cb7cca4#12ed8b060b295c06502a2ff8468e4a941cb7cca4"
+source = "git+https://github.com/anoma/masp?rev=2914e6ff9a922bae8f1cb63a79d796a69af3d8aa#2914e6ff9a922bae8f1cb63a79d796a69af3d8aa"
 dependencies = [
  "aes",
  "bip0039",
@@ -4016,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=12ed8b060b295c06502a2ff8468e4a941cb7cca4#12ed8b060b295c06502a2ff8468e4a941cb7cca4"
+source = "git+https://github.com/anoma/masp?rev=2914e6ff9a922bae8f1cb63a79d796a69af3d8aa#2914e6ff9a922bae8f1cb63a79d796a69af3d8aa"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -4154,8 +4154,8 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "namada_account"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "namada_core",
@@ -4166,8 +4166,8 @@ dependencies = [
 
 [[package]]
 name = "namada_controller"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -4176,8 +4176,8 @@ dependencies = [
 
 [[package]]
 name = "namada_core"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "bech32 0.8.1",
  "borsh",
@@ -4226,8 +4226,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "ethers",
@@ -4254,8 +4254,8 @@ dependencies = [
 
 [[package]]
 name = "namada_events"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "namada_core",
@@ -4268,8 +4268,8 @@ dependencies = [
 
 [[package]]
 name = "namada_gas"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "namada_core",
@@ -4281,8 +4281,8 @@ dependencies = [
 
 [[package]]
 name = "namada_governance"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -4304,8 +4304,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ibc"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -4334,8 +4334,8 @@ dependencies = [
 
 [[package]]
 name = "namada_io"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "async-trait",
  "kdam",
@@ -4347,8 +4347,8 @@ dependencies = [
 
 [[package]]
 name = "namada_macros"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -4359,8 +4359,8 @@ dependencies = [
 
 [[package]]
 name = "namada_merkle_tree"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "eyre",
@@ -4374,8 +4374,8 @@ dependencies = [
 
 [[package]]
 name = "namada_parameters"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -4389,8 +4389,8 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -4413,16 +4413,16 @@ dependencies = [
 
 [[package]]
 name = "namada_replay_protection"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "namada_core",
 ]
 
 [[package]]
 name = "namada_sdk"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "async-trait",
  "bimap",
@@ -4491,8 +4491,8 @@ dependencies = [
 
 [[package]]
 name = "namada_shielded_token"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4532,8 +4532,8 @@ dependencies = [
 
 [[package]]
 name = "namada_state"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "clru",
@@ -4555,8 +4555,8 @@ dependencies = [
 
 [[package]]
 name = "namada_storage"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -4574,8 +4574,8 @@ dependencies = [
 
 [[package]]
 name = "namada_systems"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -4584,8 +4584,8 @@ dependencies = [
 
 [[package]]
 name = "namada_token"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "namada_core",
@@ -4602,8 +4602,8 @@ dependencies = [
 
 [[package]]
 name = "namada_trans_token"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "konst",
  "namada_core",
@@ -4619,8 +4619,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.6.0",
@@ -4648,8 +4648,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx_env"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -4658,8 +4658,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vm"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "clru",
@@ -4680,8 +4680,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vote_ext"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "borsh",
  "namada_core",
@@ -4692,8 +4692,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vp"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -4708,8 +4708,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vp_env"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "derivative",
  "masp_primitives",
@@ -4723,8 +4723,8 @@ dependencies = [
 
 [[package]]
 name = "namada_wallet"
-version = "0.44.0"
-source = "git+https://github.com/anoma/namada#80557a926ed668cee00fb2b66b069bd47c23e632"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?branch=murisi/integrate-hw-masp#829e2920f8dd1c77648ec0c5c4e877f518b7ebeb"
 dependencies = [
  "bimap",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tendermint-rpc                   = { version = "0.38.1" }
 tendermint-testgen               = { version = "0.38.1" }
 
 # Namada dependencies
-namada_sdk        = { git = "https://github.com/anoma/namada", version = "0.44.0" }
+namada_sdk        = { git = "https://github.com/anoma/namada", branch = "murisi/integrate-hw-masp" }
 
 # Other dependencies
 abscissa_core            = "=0.6.0"

--- a/crates/relayer/src/chain/namada/tx.rs
+++ b/crates/relayer/src/chain/namada/tx.rs
@@ -47,8 +47,7 @@ impl NamadaChain {
             code_path: Some(PathBuf::from(tx::TX_IBC_WASM)),
             data_path: None,
             serialized_tx: None,
-            owner: relayer_addr.clone(),
-            disposable_signing_key: false,
+            owner: Some(relayer_addr.clone()),
         };
         let mut txs = Vec::new();
         for msg in msgs {
@@ -56,7 +55,7 @@ impl NamadaChain {
                 .block_on(args.build(&self.ctx))
                 .map_err(NamadaError::namada)?;
             self.set_tx_data(&mut tx, msg)?;
-            txs.push((tx, signing_data));
+            txs.push((tx, signing_data.expect("SigningData should exist")));
         }
         let (mut tx, signing_data) = tx::build_batch(txs).map_err(NamadaError::namada)?;
         // This is fine, as only the relayers is signing the transactions

--- a/tools/test-framework/src/util/namada.rs
+++ b/tools/test-framework/src/util/namada.rs
@@ -5,8 +5,8 @@ use ibc_relayer_types::core::ics24_host::identifier::{ChannelId, ClientId, PortI
 use ibc_relayer_types::events::IbcEventType;
 use ibc_relayer_types::Height;
 use itertools::Itertools;
-use namada_sdk::ibc::storage::{consensus_height, consensus_state_prefix};
 use namada_sdk::events::extend::Height as HeightAttr;
+use namada_sdk::ibc::storage::{consensus_height, consensus_state_prefix};
 use namada_sdk::queries::RPC;
 use namada_sdk::storage::{Key, PrefixValue};
 use namada_sdk::tx::Tx;


### PR DESCRIPTION
Applied the changes necessary to make Hermes work with https://github.com/anoma/namada/pull/3797 . It is likely that the wallet `Store` changes in that PR made it incompatible with existing Hermes releases.